### PR TITLE
Added feature to save output to files.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ CONTEXT_SIZE="128000"
 # If you want to use other OpenAI compatible API, add the following below:
 # OPENAI_ENDPOINT="http://localhost:11434/v1"
 # OPENAI_MODEL="llama3.1"
+
+# turn to true to skip the detailed report processing and just generate a test output
+DEBUG_REPORTS=false

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ next-env.d.ts
 *.pem
 *.log
 
+/generated_reports/*
+!/generated_reports/.gitkeep
+

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async rewrites() {
+    return [
+      {
+        source: '/generated_reports/:path*',
+        destination: '/api/reports/:path*',
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/app/api/reports/[reportId]/route.ts
+++ b/src/app/api/reports/[reportId]/route.ts
@@ -1,22 +1,18 @@
 import { type NextRequest, NextResponse } from 'next/server';
+import { readFile } from 'fs/promises';
+import path from 'path';
 
 export async function GET(
-  request: NextRequest,
+  _request: NextRequest,
   context: { params: Promise<{ reportId: string }> }
 ) {
   const { reportId } = await context.params;
   const reportIdWithExt = reportId.endsWith('.md') ? reportId : `${reportId}.md`;
   
   try {
-    const response = await fetch(`${request.nextUrl.origin}/generated_reports/${reportIdWithExt}`);
-    if (!response.ok) {
-      return NextResponse.json(
-        { error: 'Failed to retrieve report' },
-        { status: 404 }
-      );
-    }
+    const reportPath = path.join(process.cwd(), 'generated_reports', reportIdWithExt);
+    const report = await readFile(reportPath, 'utf-8');
     
-    const report = await response.text();
     return new NextResponse(report, {
       headers: {
         'Content-Type': 'text/markdown',

--- a/src/app/api/reports/[reportId]/route.ts
+++ b/src/app/api/reports/[reportId]/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { readFile } from 'fs/promises';
+import path from 'path';
+
+export async function GET(
+  request: Request,
+  { params }: { params: { reportId: string } }
+) {
+  try {
+    const reportPath = path.join(
+      process.cwd(),
+      'generated_reports',
+      // Ensure we're looking for a markdown file
+      params.reportId.endsWith('.md') ? params.reportId : `${params.reportId}.md`
+    );
+    
+    const report = await readFile(reportPath, 'utf-8');
+    
+    return new NextResponse(report, {
+      headers: {
+        'Content-Type': 'text/markdown',
+        'Content-Disposition': `inline; filename="${path.basename(reportPath)}"`,
+      },
+    });
+  } catch (error) {
+    console.error('[reports/route.ts] Error reading report:', error);
+    return NextResponse.json(
+      { error: 'Failed to retrieve report' },
+      { status: 404 }
+    );
+  }
+}

--- a/src/app/api/research/init/route.ts
+++ b/src/app/api/research/init/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+import crypto from 'crypto';
+import path from 'path';
+import { writeFile } from 'fs/promises';
+
+export async function POST(req: Request) {
+  try {
+    const { query } = await req.json();
+
+    // Generate a unique ID for the report
+    const reportId = crypto.randomBytes(16).toString('hex');
+    
+    // Create timestamp prefix in format YYYY-MM-DD-HH-mm
+    const now = new Date();
+    const timestamp = now.toLocaleString('en-US', { 
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false
+    }).replace(/[\/:]/g, '-').replace(',', '').replace(' ', '-');
+    
+    // Generate filenames
+    const reportFileName = `${timestamp}-${reportId}.md`;
+    const queryFileName = `${timestamp}-${reportId}.query.md`;
+    const reportPath = path.join(process.cwd(), 'generated_reports', reportFileName);
+    const queryPath = path.join(process.cwd(), 'generated_reports', queryFileName);
+    
+    // Create stub files with initial content
+    await writeFile(reportPath, '# Research in Progress\n\nYour report is being generated. Please check back in a few minutes...');
+    await writeFile(queryPath, query || 'Query processing...');
+
+    // Create the URLs for accessing both files
+    const reportUrl = `/generated_reports/${reportFileName}`;
+    const queryUrl = `/generated_reports/${queryFileName}`;
+
+    return NextResponse.json({ 
+      reportId,
+      timestamp,
+      reportUrl,
+      queryUrl,
+      reportFileName,
+      queryFileName
+    });
+  } catch (error) {
+    console.error('[research/init/route.ts] Error initializing report:', error);
+    return NextResponse.json(
+      { error: 'Failed to initialize report' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/research/route.ts
+++ b/src/app/api/research/route.ts
@@ -20,26 +20,31 @@ export async function POST(req: Request) {
       .join('\n')}`;
 
     console.log("[route.ts] Starting deep research with query:", combinedQuery);
+    let report = "";
 
-    // Perform research
-    const { learnings, visitedUrls } = await deepResearch({
-      query: combinedQuery,
-      breadth,
-      depth,
-    });
+    if ( process.env.DEBUG_REPORTS !== 'true' ) {
+      // Perform research
+      const { learnings, visitedUrls } = await deepResearch({
+        query: combinedQuery,
+        breadth,
+        depth,
+      });
 
-    console.log("[route.ts] Deep research completed. Writing final report...");
+      console.log("[route.ts] Deep research completed. Writing final report...");
 
-    // Generate report using combinedQuery for both 'query' and 'prompt'
-    console.log("[route.ts] Generating final report with combinedQuery as both query and prompt.");
-    const report = await writeFinalReport({
-      query: combinedQuery,
-      prompt: combinedQuery,
-      learnings,
-      visitedUrls,
-    });
+      // Generate report using combinedQuery for both 'query' and 'prompt'
+      console.log("[route.ts] Generating final report with combinedQuery as both query and prompt.");
+      report = await writeFinalReport({
+        query: combinedQuery,
+        prompt: combinedQuery,
+        learnings,
+        visitedUrls,
+      });
 
-    console.log("[route.ts] Final report generated.");
+      console.log("[route.ts] Final report generated.");
+    } else {
+      report = "This is a test";
+    }
     
     // Save the report to a markdown file
     const reportPath = path.join(process.cwd(), 'generated_reports', reportFileName);

--- a/src/app/api/research/route.ts
+++ b/src/app/api/research/route.ts
@@ -1,6 +1,8 @@
 import { deepResearch, writeFinalReport } from '@/lib/deep-research';
 import { NextResponse } from 'next/server';
 import crypto from 'crypto';
+import { writeFile } from 'fs/promises';
+import path from 'path';
 
 export async function POST(req: Request) {
   try {
@@ -36,8 +38,43 @@ export async function POST(req: Request) {
 
     // Generate a unique ID for the report
     const reportId = crypto.randomBytes(16).toString('hex');
+    
+    // Create timestamp prefix in format YYYY-MM-DD-HH-mm
+    const now = new Date();
+    const timestamp = now.toLocaleString('en-US', { 
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false
+    }).replace(/[\/:]/g, '-').replace(',', '').replace(' ', '-');
+    
+    // Save the report to a markdown file
+    const reportFileName = `${timestamp}-${reportId}.md`;
+    const reportPath = path.join(process.cwd(), 'generated_reports', reportFileName);
+    
+    // Save the raw markdown content directly
+    await writeFile(reportPath, report);
 
-    return NextResponse.json({ reportId, report });
+    // Save the query to a separate markdown file
+    const queryFileName = `${timestamp}-${reportId}.query.md`;
+    const queryPath = path.join(process.cwd(), 'generated_reports', queryFileName);
+    await writeFile(queryPath, combinedQuery);
+
+    console.log(`[route.ts] Report and query saved to ${reportPath} and ${queryPath}`);
+
+    // Create the URLs for accessing both files
+    const reportUrl = `/generated_reports/${reportFileName}`;
+    const queryUrl = `/generated_reports/${queryFileName}`;
+
+    return NextResponse.json({ 
+      reportId, 
+      report, 
+      reportUrl,
+      query: combinedQuery,
+      queryUrl
+    });
   } catch (error) {
     console.error('[route.ts] Error performing research:', error);
     return NextResponse.json(
@@ -46,4 +83,3 @@ export async function POST(req: Request) {
     );
   }
 }
-


### PR DESCRIPTION
I added a simple feature to save the reports to files.  Then the links are shown to the user while the report is being processed.  This will help with client-side timeouts (or server-side if you run through a nginx proxy) where the backend is still processing but the user has to way to retrieve it on the frontend.

I also added a simple debug flag to the .env setup to skip the long report processing, as a quick way to run tests.

This was more useful for me, but do with it what you'd like :-) 